### PR TITLE
chore(build): use rimraf instead of unlink

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,13 @@
   "license": "MIT",
   "repository": "pandawing/generator-nm",
   "scripts": {
-    "example": "npm run example:link && npm run example:build",
-    "example:build": "cd example && ../node_modules/yo/lib/cli.js @sanemat/nm && unlink node_modules/@sanemat/generator-nm && cd ..",
+    "example": "npm run example:link && npm run example:build && npm run example:unlink",
+    "example:build": "cd example && ../node_modules/yo/lib/cli.js @sanemat/nm && cd ..",
     "example:link": "rimraf example && mkdirp example/node_modules/@sanemat && lnfs . example/node_modules/@sanemat/generator-nm",
+    "example:unlink": "rimraf example/node_modules/@sanemat/generator-nm",
     "git:tag": "git tag v${npm_package_version}",
     "test": "mocha",
-    "verify": "npm run test && npm run example:link && npm run verify:link",
+    "verify": "npm run test && npm run example:link && npm run verify:link && npm run example:unlink && npm run verify:link",
     "verify:link": "nodetree -L 2 example/node_modules/@sanemat/"
   }
 }


### PR DESCRIPTION
windows does not have `unlink`.